### PR TITLE
fix: correct memory-saving taylor forward pass

### DIFF
--- a/zoology/mixers/based.py
+++ b/zoology/mixers/based.py
@@ -69,11 +69,11 @@ class TaylorExp(FeatureMap):
         -> Assume x.shape is (batch_size, n_heads, seq_len, head_dim)
         """
         # Slow but memory-saving way to compute 2nd-order terms; how do w/o outer-product first?
-        x2  = oe.contract('...m,...n->...mn', x, x) / self.input_dim
+        x2  = oe.contract('...m,...n->...mn', x, x) / self.rd
         x2d = torch.diagonal(x2, dim1=-2, dim2=-1) / self.r2
         x2  = x2[..., self.tril_indices[0], self.tril_indices[1]]
         x   = torch.cat([torch.ones(x[..., :1].shape).to(x.device), 
-                         x / self.rd, x2d, x2], dim=-1)
+                         x / self.rrd, x2d, x2], dim=-1)
         return x 
 
 


### PR DESCRIPTION
`forward_mem_save` in `TaylorExp` is bugged.

There aren't tests in this repo but here is a quick test

```python
def exp_taylor(x, n=2):
    s = 0

    for i in range(n+1):
        s += x**i/math.factorial(i)
    
    return s

d = 16

q = torch.randn(d)
q_uns = q.view(1, 1, 1, -1)

k = torch.randn(d)
k_uns = k.view(1, 1, 1, -1)

te_model = TaylorExp(d)

from_taylor = exp_taylor(np.dot(q, k)/np.sqrt(d), n=2)
from_forward = (te_model.forward(q_uns) * te_model.forward(k_uns)).sum(dim=-1).item()
from_forward_mem = (te_model.forward_mem_save(q_uns) * te_model.forward_mem_save(k_uns)).sum(dim=-1).item()

assert np.allclose(from_taylor, from_forward)
assert np.allclose(from_taylor, from_forward_mem)
```

The code currently passes the first assert and fails the second assert. This PR passes the second.