### PR TITLE
Fix the dataconfig changes after 194a712

### DIFF
--- a/zoology/experiments/examples/basic.py
+++ b/zoology/experiments/examples/basic.py
@@ -1,19 +1,15 @@
-from zoology.config import TrainConfig, ModelConfig, DataConfig, FunctionConfig, ModuleConfig
+from zoology.config import TrainConfig, ModelConfig, DataConfig, ModuleConfig
+from zoology.data.associative_recall import MQARConfig
 
-
+factory_kwargs = {
+        "num_kv_pairs": 4,
+    }
 
 config = TrainConfig(
     data=DataConfig(
         # cache_dir="/path/to/cache/dir"  TODO: add this
-        vocab_size=256,
-        input_seq_len=64,
-        num_train_examples=10_000,
-        num_test_examples=1_000,
-        builder=FunctionConfig(
-            name="zoology.data.associative_recall.multiquery_ar",
-            kwargs={"num_kv_pairs": 4}
-        ),
-        
+        train_configs=[MQARConfig(num_examples=10_000, vocab_size=256, input_seq_len=64, **factory_kwargs)],
+        test_configs=[MQARConfig(num_examples=1_000, vocab_size=256, input_seq_len=64, **factory_kwargs)],
     ),
     model=ModelConfig(
         vocab_size=256,

--- a/zoology/experiments/examples/basic_sweep.py
+++ b/zoology/experiments/examples/basic_sweep.py
@@ -1,26 +1,20 @@
 import numpy as np
-from zoology.config import TrainConfig
-from zoology.config import TrainConfig, ModelConfig, DataConfig, FunctionConfig, ModuleConfig
-
-from zoology.config import TrainConfig, ModelConfig, DataConfig, FunctionConfig, ModuleConfig
+from zoology.config import TrainConfig, ModelConfig, DataConfig, ModuleConfig
+from zoology.data.associative_recall import MQARConfig
 
 
 configs = []
+factory_kwargs = {
+        "num_kv_pairs": 4,
+    }
 
 for lr in np.logspace(-4, -2, 10):
 
    config = TrainConfig(
       data=DataConfig(
          # cache_dir="/path/to/cache/dir"  TODO: add a directory where data will be cached
-         vocab_size=256,
-         input_seq_len=64,
-         num_train_examples=10_000,
-         num_test_examples=1_000,
-         builder=FunctionConfig(
-               name="zoology.data.associative_recall.multiquery_ar",
-               kwargs={"num_kv_pairs": 4}
-         ),
-         
+         train_configs=[MQARConfig(num_examples=10_000, vocab_size=256, input_seq_len=64, **factory_kwargs)],
+         test_configs=[MQARConfig(num_examples=1_000, vocab_size=256, input_seq_len=64, **factory_kwargs)],
       ),
       model=ModelConfig(
          vocab_size=256,


### PR DESCRIPTION
Hi
I got the running errors about missing field following the ReadMe tutorial. 

```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for DataConfig
train_configs
  Field required [type=missing, input_value={'vocab_size': 256, 'inpu...gs={'num_kv_pairs': 4})}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/missing
test_configs
  Field required [type=missing, input_value={'vocab_size': 256, 'inpu...gs={'num_kv_pairs': 4})}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/missing
```

It might caused by DataConfig update on commit 194a712, I updated the DataConfig in basic and basic_sweep, not sure it has the same behavior as previous code before DataConfig change.