### PR TITLE
Fix: Correct RWKV-7 state_size calculation

### DIFF
--- a/zoology/mixers/rwkv7.py
+++ b/zoology/mixers/rwkv7.py
@@ -209,7 +209,7 @@ class RWKV7Attention(nn.Module):
 
     def state_size(self, sequence_length: int=2048):
         return (
-            self.num_heads * self.key_dim * self.value_dim
+            self.num_heads * self.head_dim * self.value_dim
         )
 
 


### PR DESCRIPTION
This PR corrects the `state_size` calculation for the RWKV-7 model, based on a suggestion from Peng Bo, the author of RWKV-7. The calculation now uses `self.head_dim` instead of `self.key_dim` for improved accuracy.