### PR TITLE
Fix: Complete RWKV-7 state_size calculation correction

### DIFF
--- a/zoology/mixers/rwkv7.py
+++ b/zoology/mixers/rwkv7.py
@@ -209,7 +209,7 @@ class RWKV7Attention(nn.Module):
 
     def state_size(self, sequence_length: int=2048):
         return (
-            self.num_heads * self.head_dim * self.value_dim
+            self.num_heads * self.head_dim * self.head_dim
         )
 
 


### PR DESCRIPTION
This PR further corrects the `state_size` calculation for RWKV-7, completing the previous partial fix. The calculation now correctly uses `self.head_dim * self.head_dim` instead of `self.head_dim * self.value_dim`, as originally suggested by Peng Bo.